### PR TITLE
fix(platform): stop runs list from loading full analysis payloads

### DIFF
--- a/packages/platform/qym_platform/_static/dashboard/charts.html
+++ b/packages/platform/qym_platform/_static/dashboard/charts.html
@@ -93,6 +93,6 @@
 
   <script>window.__QYM_INITIAL_VIEW__ = 'charts';</script>
   <script src="/static/metrics.js"></script>
-  <script src="/static/dashboard.js?v=pass-live-progress-20260810-25"></script>
+  <script src="/static/dashboard.js?v=repeat-compare-pass-selection-20260818-39"></script>
 </body>
 </html>

--- a/packages/platform/qym_platform/_static/dashboard/dashboard.js
+++ b/packages/platform/qym_platform/_static/dashboard/dashboard.js
@@ -5937,6 +5937,8 @@
   // ═══════════════════════════════════════════════════
 
   const PAGE_SIZE = 100;
+  // Bounds in-flight page requests without bounding how many are fetched.
+  const PAGE_CONCURRENCY = 3;
   const LIVE_REFRESH_INTERVAL_MS = 15000;
   const IDLE_REFRESH_INTERVAL_MS = 60000;
   const FULL_REFRESH_STALE_MS = 5 * 60 * 1000;
@@ -5988,11 +5990,12 @@
 
   function saveRunsDataCache(data) {
     try {
-      const payload = {
-        saved_at: Date.now(),
-        data: _cloneRunsData(data),
-      };
-      sessionStorage.setItem(getRunsCacheKey(), JSON.stringify(payload));
+      // JSON.stringify already snapshots the payload, so the extra
+      // _cloneRunsData round trip only doubled the peak for no benefit.
+      sessionStorage.setItem(
+        getRunsCacheKey(),
+        JSON.stringify({ saved_at: Date.now(), data }),
+      );
     } catch {}
   }
 
@@ -6081,26 +6084,33 @@
   }
 
   async function _fetchRemainingPages(data, totalCount) {
-    // Fetch remaining pages in the background and merge into state
+    // Fetch remaining pages in the background and merge into state.  Every page
+    // is still fetched -- nothing is capped or dropped -- but a fixed worker
+    // pool bounds how many are in flight, and each page is merged as it lands
+    // instead of every response being retained until the last one resolves.
     const fetched = PAGE_SIZE; // first page already loaded
     if (fetched >= totalCount) return;
 
-    const pagePromises = [];
-    const projectSlug = state.currentProject && state.currentProject.slug ? `&project_slug=${encodeURIComponent(state.currentProject.slug)}` : '';
+    const offsets = [];
     for (let offset = fetched; offset < totalCount; offset += PAGE_SIZE) {
-      pagePromises.push(
-        fetch(apiUrl(`api/runs?limit=${PAGE_SIZE}&offset=${offset}${projectSlug}`))
+      offsets.push(offset);
+    }
+
+    const projectSlug = state.currentProject && state.currentProject.slug ? `&project_slug=${encodeURIComponent(state.currentProject.slug)}` : '';
+    let cursor = 0;
+    const drainPages = async () => {
+      while (cursor < offsets.length) {
+        if (!dashboardActive) return;
+        const offset = offsets[cursor++];
+        const page = await fetch(apiUrl(`api/runs?limit=${PAGE_SIZE}&offset=${offset}&include_total=false${projectSlug}`))
           .then(r => r.ok ? r.json() : null)
-          .catch(() => null)
-      );
-    }
+          .catch(() => null);
+        if (page) _mergeTasksData(data, page);
+      }
+    };
 
-    const pages = await Promise.all(pagePromises);
+    await Promise.all(Array.from({ length: PAGE_CONCURRENCY }, drainPages));
     if (!dashboardActive) return;
-
-    for (const page of pages) {
-      if (page) _mergeTasksData(data, page);
-    }
 
     // Re-apply with full data
     _applyRunsData(data);

--- a/packages/platform/qym_platform/_static/dashboard/index.html
+++ b/packages/platform/qym_platform/_static/dashboard/index.html
@@ -216,6 +216,6 @@
   <script>window.__QYM_INITIAL_VIEW__ = 'table';</script>
   <script src="/static/metrics.js"></script>
   <script src="/static/qym_table.js"></script>
-  <script src="/static/dashboard.js?v=repeat-compare-pass-selection-20260812-38"></script>
+  <script src="/static/dashboard.js?v=repeat-compare-pass-selection-20260818-39"></script>
 </body>
 </html>

--- a/packages/platform/qym_platform/_static/dashboard/models.html
+++ b/packages/platform/qym_platform/_static/dashboard/models.html
@@ -129,6 +129,6 @@
 
   <script>window.__QYM_INITIAL_VIEW__ = 'models';</script>
   <script src="/static/metrics.js"></script>
-  <script src="/static/dashboard.js?v=pass-live-progress-20260810-25"></script>
+  <script src="/static/dashboard.js?v=repeat-compare-pass-selection-20260818-39"></script>
 </body>
 </html>

--- a/packages/platform/qym_platform/api/runs.py
+++ b/packages/platform/qym_platform/api/runs.py
@@ -1616,6 +1616,14 @@ def legacy_list_runs(
     exclude_live: bool = Query(
         default=False, description="Exclude live run statuses from the result set"
     ),
+    include_total: bool = Query(
+        default=True,
+        description=(
+            "Compute total_count. Defaults to true so existing clients are "
+            "unaffected; pagers that already know the total can pass false to "
+            "skip a full count on every page."
+        ),
+    ),
     user: Optional[str] = Query(
         default=None, description="Filter by run owner user id, email, or display name"
     ),
@@ -1707,8 +1715,10 @@ def legacy_list_runs(
             )
         )
 
-    # Total count before pagination
-    total_count = q.count()
+    # Total count before pagination.  The count scans the whole project, so a
+    # pager walking N pages paid for it N times; callers that already have it
+    # can opt out.
+    total_count = q.count() if include_total else None
 
     # Apply pagination
     runs: List[Run] = q.offset(offset).limit(limit).all()
@@ -1885,14 +1895,22 @@ def legacy_list_runs(
         # A repeat-run diagnosis is stored on the pass score, not on the
         # reduced RunItem.  Keep the runs-list chip scoped to that pass so a
         # diagnosis on one sample cannot appear on every sample row.
+        # Only pass scores that carry an analysis payload can contribute a
+        # cause; the loop below discards the rest.  Applying that predicate in
+        # SQL and streaming the result keeps this independent of pass volume.
         pass_analysis_rows = (
             db.query(
                 RunItemPassScore.run_id,
                 RunItemPassScore.pass_number,
                 RunItemPassScore.meta,
             )
-            .filter(RunItemPassScore.run_id.in_(sampled_run_ids))
-            .all()
+            .filter(
+                RunItemPassScore.run_id.in_(sampled_run_ids),
+                cast(RunItemPassScore.meta, Text).like(
+                    f'%"{PASS_ANALYSIS_META_KEY}"%'
+                ),
+            )
+            .yield_per(1000)
         )
         pass_analysis_causes: Dict[str, Dict[int, set[str]]] = {}
         for rid, pass_number, meta in pass_analysis_rows:
@@ -1966,7 +1984,7 @@ def legacy_list_runs(
             RunItem.run_id.in_(run_ids),
             cast(RunItem.item_metadata, Text).like('%"root_cause"%'),
         )
-        .all()
+        .yield_per(1000)
     )
     analysis_causes: Dict[str, set] = {}
     for row in analysis_rows:
@@ -3213,8 +3231,11 @@ def run_passes(
 
     pass_analysis_rows = (
         db.query(RunItemPassScore.pass_number, RunItemPassScore.meta)
-        .filter(RunItemPassScore.run_id == run.id)
-        .all()
+        .filter(
+            RunItemPassScore.run_id == run.id,
+            cast(RunItemPassScore.meta, Text).like(f'%"{PASS_ANALYSIS_META_KEY}"%'),
+        )
+        .yield_per(1000)
     )
     pass_analysis_causes: Dict[int, set[str]] = {}
     for pass_number, meta in pass_analysis_rows:

--- a/packages/platform/qym_platform/cli.py
+++ b/packages/platform/qym_platform/cli.py
@@ -14,4 +14,3 @@ def main() -> None:
 if __name__ == "__main__":
     main()
 
-

--- a/packages/platform/qym_platform/db/session.py
+++ b/packages/platform/qym_platform/db/session.py
@@ -15,4 +15,3 @@ def _build_engine():
 engine = _build_engine()
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
-

--- a/packages/platform/qym_platform/deps.py
+++ b/packages/platform/qym_platform/deps.py
@@ -14,4 +14,3 @@ def get_db() -> Generator[Session, None, None]:
     finally:
         db.close()
 
-


### PR DESCRIPTION
## Summary
Opening a large project exhausted memory and took the platform down. This fixes
the regression plus the pre-existing amplifier that made it fatal.

## Root cause
**Regression (new in #29/#30):** `api/runs.py:1888` and `:3216` fetch every
`RunItemPassScore` row with its full `meta` blob for repeat runs. Row count is
`items x metrics x passes`; one run with 500 items, 3 metrics and 5 passes is
7,500 rows, and a page of 40 such runs is 300,000 -- on every request. The
previous release fetched **zero** of these. Both are gated on `samples > 1`.

**Amplifier (pre-existing, since 9353a7c):** `_fetchRemainingPages` issued
`ceil(runs/100)` requests *simultaneously* via `Promise.all` and retained every
response. A 100,000-run project meant 999 concurrent requests. One page load
produced 318 completed requests in 2m20s and burned 1,099s of server time.

## Changes

| file | change |
|---|---|
| `api/runs.py:1888` | Filter pass analysis in SQL, stream with `yield_per` |
| `api/runs.py:3216` | Same, for `/api/runs/{id}/passes` |
| `api/runs.py:1977` | Stream the `item_metadata` scan instead of buffering |
| `api/runs.py` | Optional `include_total` (defaults true -- old clients unaffected) |
| `dashboard.js` | Bound page fetches to 3 concurrent; merge each page as it lands |
| `dashboard.js` | Drop the redundant deep clone before caching |
| `*.html` | Bump the cache-bust tag so browsers pick up the new JS |

**No database change. No migration.

## Correctness

Old and new paths run side by side on real data, folded through the unmodified
production loop:

FIX 1+2 (pass analysis)
  OLD  .all(), no filter        rows=  4517   peak=  3.8 MB
  NEW  filtered + yield_per     rows=   196   peak=  1.2 MB
  -> IDENTICAL RESULT: True

FIX 6 (item metadata)
  old  rows=50000   peak= 184.5 MB   sha=34a5996f3ac13537
  new  rows=50000   peak=   7.5 MB   sha=34a5996f3ac13537

The rows no longer fetched are rows the loop already discarded after fetching.
Client fan-out verified against the shipped source: all 999 pages still
requested for a 100,000-run project, no offset skipped, max 3 in flight.

**No cap, no sampling, no truncation.**

## Before / after

Measured on a 100,000-run project:

| | before | after |
|---|---|---|
| API memory | climbed until the platform dropped | **208 MB, flat** |
| DB memory | 4.1 GB | 474 MB |
| peak concurrent requests | 6, saturated for minutes | 4 |
| median `/api/runs` | 2,648 ms | **1,039 ms** |
| slowest request | 15,276 ms | 4,307 ms |
| errors | -- | **0** |

## Testing

`pytest tests/platform -q` -> **477 passed, 21 skipped, 0 failed**

Backward compatibility verified live: a client omitting `include_total` still
receives `total_count` exactly as before.

## Known limitations

- **Browser memory is improved, not solved.** With no cap the tab still
  accumulates every run it fetches. A large enough project can still make the
  tab sluggish; the server stays up. Fixing this needs server-side aggregation.
- **Not tested at production data shape.** The dev database has 5 repeat runs;
  production has real ones. The logic is proven; the scale is not.
- **The ANALYSIS column still costs ~50% of each request** and grows with every
  analysis run, because the cause count is recomputed from item metadata each
  time. A stored count would fix it but would require a schema change.
- **Do not add uvicorn workers.** `services/analysis_jobs.py` keeps its job
  registry in process memory and assumes a single worker.